### PR TITLE
Fix manifest name & description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Buy me a coffee logo](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWlscGFteGJsejlxNmQ0dzNyZGg5YzVsNDB6bXN1Z2Ewd2FoNTBiYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9cw/McUSEJHHoZMUL99iW9/giphy.gif)](https://buymeacoffee.com/danrfletcher)
 
-# Agile Obsidian Documentation
+# Obsidian Agile Project Management Documentation
 
 **Version: 1.0.0**
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-	"id": "agile-obsidian",
-	"name": "Agile Obsidian",
+	"id": "agile-project-management",
+	"name": "Agile Project Management",
 	"version": "1.0.1",
 	"minAppVersion": "0.15.0",
-	"description": "Turns Obsidian into a powerful collaborative Agile productivity hub inspired by ClickUp, Jira, and Notion.",
+	"description": "Turns your vault into a powerful collaborative Agile productivity hub inspired by ClickUp, Jira, and Notion.",
 	"author": "danrfletcher",
 	"authorUrl": "https://github.com/danrfletcher/",
 	"fundingUrl": "https://buymeacoffee.com/danrfletcher",


### PR DESCRIPTION
Fixes: 

Errors:

❌ Please don't use the word obsidian in the plugin ID. The ID is used for your plugin's folder so keeping it short and simple avoids clutter and helps with sorting.
❌ Please don't use the word Obsidian in your plugin name since it's redundant and adds clutter to the plugin list.
❌ Please don't parts of the name Obsidian in the plugin name, it's redundant
❌ Please don't include Obsidian in the plugin description

Required for Obsidian plugin submission